### PR TITLE
chore: promote demo-react to version 0.0.3

### DIFF
--- a/config-root/namespaces/harbor/harbor/templates/core/harbor-core-deploy.yaml
+++ b/config-root/namespaces/harbor/harbor/templates/core/harbor-core-deploy.yaml
@@ -29,8 +29,8 @@ spec:
         component: core
       annotations:
         checksum/configmap: 60694b291eee0b9d4cbfa0cdf5110dae964fa68f04cf3296d787c78f83fba6e2
-        checksum/secret: 95e5674c84f0701954aed7ddb3a949874752059c3f526ca79996d27a5bcb7c5b
-        checksum/secret-jobservice: 13b6147a48b05bbdb3a545e2b4171385cf8f5279e629362bd92388a594b46239
+        checksum/secret: 78fb7c13ad1ce27fa4d14f6777b294d82ada4038382cdb26a5022f4f821e9e70
+        checksum/secret-jobservice: 2e09e17989b4a158671179d5a8494db8b954737d76a545c9eeb706c9e2fa4771
     spec:
       securityContext:
         runAsUser: 10000

--- a/config-root/namespaces/harbor/harbor/templates/jobservice/harbor-jobservice-deploy.yaml
+++ b/config-root/namespaces/harbor/harbor/templates/jobservice/harbor-jobservice-deploy.yaml
@@ -34,8 +34,8 @@ spec:
       annotations:
         checksum/configmap: 41138a089428e6776014e59b1a37c5e69bedc9331ccdb1f382f1950882ec1b7e
         checksum/configmap-env: 5c0e2cf333f81a4f19f13c25cb45f2b2f5353c9bd05f59e8cbb6b59cc0eb7195
-        checksum/secret: d0c804a4165d6657e99d32489aa337e276e8ea0e9637e18ecfe67725af6d50e2
-        checksum/secret-core: 9ae9a2a76fea01126241bd2650600de0f5f56087013150c5bc644cf0909bccf2
+        checksum/secret: 4565725de3de93f80df652f2178f83dbbf375a7dfb43b7b8e3a71ffdd90bff5e
+        checksum/secret-core: c6b838f587c560b17706e7e6cb17c2c1fcce130fa808fae322495d3f65df489f
     spec:
       securityContext:
         runAsUser: 10000

--- a/config-root/namespaces/harbor/harbor/templates/registry/harbor-registry-deploy.yaml
+++ b/config-root/namespaces/harbor/harbor/templates/registry/harbor-registry-deploy.yaml
@@ -33,9 +33,9 @@ spec:
         component: registry
       annotations:
         checksum/configmap: dbbd548871ae33e48eb16af08dc415671c1a982eea0685ce1a94015b9a0e5dcd
-        checksum/secret: 218e2c404e3a5c54d5649d5318cd7e6610fd14b493d6236ea0e067c25f708e49
-        checksum/secret-jobservice: 7e1f55ae3a57adb2f9145b6536da2f4a9462f8324d0cb1ba7d1ab1c3a370d320
-        checksum/secret-core: 7beb6aad683ec2e2322f7f0c64756e589e6395d2deaec4729f4e968ea552b35a
+        checksum/secret: 0dfacbcca0c1233eafe2ac83536068e3ae262b87e943f4c05ebef4fd08c8e09c
+        checksum/secret-jobservice: eec72a5c0e75e4f1c0eff4e99d83c2c066762a3308d2daeac8679fa268d37999
+        checksum/secret-core: 231874e73391448db127303047c4d82f276683a9131862b39c3c9cac7db04658
     spec:
       securityContext:
         runAsUser: 10000

--- a/config-root/namespaces/jx-staging/demo-react/demo-react-demo-react-deploy.yaml
+++ b/config-root/namespaces/jx-staging/demo-react/demo-react-demo-react-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: demo-react-demo-react
   labels:
     draft: draft-app
-    chart: "demo-react-0.0.1"
+    chart: "demo-react-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'demo-react'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: demo-react-demo-react
       containers:
         - name: demo-react
-          image: "ghcr.io/simonjamesrowe/demo-react:0.0.1"
+          image: "harbor.simonjamesrowe.com/simonjamesrowe/demo-react:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/demo-react/demo-react-svc.yaml
+++ b/config-root/namespaces/jx-staging/demo-react/demo-react-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: demo-react
   labels:
-    chart: "demo-react-0.0.1"
+    chart: "demo-react-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'demo-react'

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> demo-react </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.3</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -199,13 +199,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.3
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-12-13T06:15:07Z"
+    firstDeployed: "2021-12-13T07:21:35Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-12-13T06:15:07Z"
+    lastDeployed: "2021-12-13T07:21:35Z"
     name: demo-react
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/demo-react
-    version: 0.0.1
+    version: 0.0.3

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/demo-react
-  version: 0.0.1
+  version: 0.0.3
   name: demo-react
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote demo-react to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
